### PR TITLE
Twig embed instead of extends

### DIFF
--- a/templates/news/node--news--full.html.twig
+++ b/templates/news/node--news--full.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block content -%}
 <div class="cwd-component cwd-news full">
 

--- a/templates/news/node--news--full.html.twig
+++ b/templates/news/node--news--full.html.twig
@@ -1,7 +1,5 @@
 {% embed "node.html.twig" %}
-
 {% block content -%}
-
 <div class="cwd-component cwd-news full">
 
   <div class="date full-margin">
@@ -39,5 +37,4 @@
 
 </div>
 {% endblock %}
-
 {% endembed %}

--- a/templates/news/node--news--full.html.twig
+++ b/templates/news/node--news--full.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 
 {% block content -%}
 
@@ -39,3 +39,5 @@
 
 </div>
 {% endblock %}
+
+{% endembed %}

--- a/templates/news/node--news--teaser.html.twig
+++ b/templates/news/node--news--teaser.html.twig
@@ -1,7 +1,5 @@
 {% embed "node.html.twig" %}
-
 {% block title -%}{% endblock %}
-
 {% block content -%}
 
   {% set destination_url = url %}
@@ -44,5 +42,4 @@
   </div>
 
 {% endblock %}
-
 {% endembed %}

--- a/templates/news/node--news--teaser.html.twig
+++ b/templates/news/node--news--teaser.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 
 {% block title -%}{% endblock %}
 
@@ -44,3 +44,5 @@
   </div>
 
 {% endblock %}
+
+{% endembed %}

--- a/templates/news/node--news--teaser.html.twig
+++ b/templates/news/node--news--teaser.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block title -%}{% endblock %}
 {% block content -%}
 

--- a/templates/news/node--news.html.twig
+++ b/templates/news/node--news.html.twig
@@ -1,7 +1,5 @@
 {% embed "node.html.twig" %}
-
 {% block title -%}{% endblock %}
-
 {% block content -%}
 
   {% set destination_url = url %}
@@ -47,5 +45,4 @@
   </div>
 
 {% endblock %}
-
 {% endembed %}

--- a/templates/news/node--news.html.twig
+++ b/templates/news/node--news.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block title -%}{% endblock %}
 {% block content -%}
 

--- a/templates/news/node--news.html.twig
+++ b/templates/news/node--news.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 
 {% block title -%}{% endblock %}
 
@@ -47,3 +47,5 @@
   </div>
 
 {% endblock %}
+
+{% endembed %}

--- a/templates/people/node--person--full.html.twig
+++ b/templates/people/node--person--full.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 {% block content %}
 <div class="cwd-component cwd-basic cwd-people full flex-grid">
 
@@ -64,3 +64,4 @@
   </div>
 </div>
 {% endblock %}
+{% endembed %}

--- a/templates/people/node--person--full.html.twig
+++ b/templates/people/node--person--full.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block content %}
 <div class="cwd-component cwd-basic cwd-people full flex-grid">
 

--- a/templates/people/node--person.html.twig
+++ b/templates/people/node--person.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block title -%}{% endblock %}
 {% block content -%}
 

--- a/templates/people/node--person.html.twig
+++ b/templates/people/node--person.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 {% block title -%}{% endblock %}
 {% block content -%}
 
@@ -32,3 +32,4 @@
   {% endif %}
 
 {% endblock %}
+{% endembed %}

--- a/templates/slideshow/node--slideshow.html.twig
+++ b/templates/slideshow/node--slideshow.html.twig
@@ -1,6 +1,6 @@
-{% extends "@cwd_base/slideshow/node--slideshow.html.twig" %}
 {# Override the container markup and cwd_slider() JavaScript function to configure slider options for the site. #}
 
+{% embed "@cwd_base/slideshow/node--slideshow.html.twig" %}
 {# Slider Markup #}
 {% block container_override %}
   {% if is_front %}
@@ -21,3 +21,5 @@
     <script>cwd_slider('#slider{{ node.id }}','#slider-headline{{ node.id }}',8,1,false,true);</script>
   {% endif %}
 {% endblock %}
+
+{% endembed %}

--- a/templates/slideshow/node--slideshow.html.twig
+++ b/templates/slideshow/node--slideshow.html.twig
@@ -21,5 +21,4 @@
     <script>cwd_slider('#slider{{ node.id }}','#slider-headline{{ node.id }}',8,1,false,true);</script>
   {% endif %}
 {% endblock %}
-
 {% endembed %}

--- a/templates/spotlights/node--spotlight--full.html.twig
+++ b/templates/spotlights/node--spotlight--full.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 
 {% block content -%}
 
@@ -35,3 +35,5 @@
 
 </div>
 {% endblock %}
+
+{% endembed %}

--- a/templates/spotlights/node--spotlight--full.html.twig
+++ b/templates/spotlights/node--spotlight--full.html.twig
@@ -1,7 +1,5 @@
 {% embed "node.html.twig" %}
-
 {% block content -%}
-
 <div class="cwd-component cwd-spotlight full">
 
   {% if node.field_image.value %}
@@ -35,5 +33,4 @@
 
 </div>
 {% endblock %}
-
 {% endembed %}

--- a/templates/spotlights/node--spotlight--full.html.twig
+++ b/templates/spotlights/node--spotlight--full.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block content -%}
 <div class="cwd-component cwd-spotlight full">
 

--- a/templates/spotlights/node--spotlight--teaser.html.twig
+++ b/templates/spotlights/node--spotlight--teaser.html.twig
@@ -1,7 +1,5 @@
 {% embed "node.html.twig" %}
-
 {% block title -%}{% endblock %}
-
 {% block content -%}
 
   {% set destination_url = url %}
@@ -39,6 +37,5 @@
     </div>
   {%- endif %}
   </div>
-
 {% endblock %}
 {% endembed %}

--- a/templates/spotlights/node--spotlight--teaser.html.twig
+++ b/templates/spotlights/node--spotlight--teaser.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block title -%}{% endblock %}
 {% block content -%}
 

--- a/templates/spotlights/node--spotlight--teaser.html.twig
+++ b/templates/spotlights/node--spotlight--teaser.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 
 {% block title -%}{% endblock %}
 
@@ -41,3 +41,4 @@
   </div>
 
 {% endblock %}
+{% endembed %}

--- a/templates/spotlights/node--spotlight.html.twig
+++ b/templates/spotlights/node--spotlight.html.twig
@@ -1,7 +1,5 @@
 {% embed "node.html.twig" %}
-
 {% block title -%}{% endblock %}
-
 {% block content -%}
 
   {% set destination_url = url %}
@@ -44,5 +42,4 @@
   </div>
 
 {% endblock %}
-
 {% endembed %}

--- a/templates/spotlights/node--spotlight.html.twig
+++ b/templates/spotlights/node--spotlight.html.twig
@@ -1,4 +1,4 @@
-{% extends "node.html.twig" %}
+{% embed "node.html.twig" %}
 
 {% block title -%}{% endblock %}
 
@@ -44,3 +44,5 @@
   </div>
 
 {% endblock %}
+
+{% endembed %}

--- a/templates/spotlights/node--spotlight.html.twig
+++ b/templates/spotlights/node--spotlight.html.twig
@@ -1,4 +1,4 @@
-{% embed "node.html.twig" %}
+{% embed "@cwd_base/node.html.twig" %}
 {% block title -%}{% endblock %}
 {% block content -%}
 


### PR DESCRIPTION
I think this is uncontroversial, but, any objections?

To test, look at news/people/spotlight/slideshow content on the demo site > "alison" multidev -- events are not affected.
- [x] Homepage slideshow: https://alison-cddemo.pantheonsite.io
- [x] Click each of News, Spotlights People, in the main menu.
- [x] Click through to one of each content type (news/people/spotlight) to check a node page display.
- [x] News/Spotlights bands at the bottom of every page on the site.

What's inside:
* Replace all instances of `extends` with `embed`/`endembed`
* Add `cwd_base` namespace to all file references -- see associated GH issue for why I did this.

----

NOTE: There'll be no "backwards compatibility" issues (because no sites use cwd_project except the demo site), and it's not important enough to bother updating on existing sites with child themes that were built from cwd_project.  This is just, a nice, low-key syntax improvement.