### PR TITLE
new template for event ctype full view mode

### DIFF
--- a/templates/events/node--event--full.html.twig
+++ b/templates/events/node--event--full.html.twig
@@ -1,0 +1,23 @@
+{% extends "node.html.twig" %}
+{% block content -%}
+<div class="cwd-component cwd-basic cwd-event full">
+
+  {{ content.field_event_image }}
+
+  <div class="group-fields">
+    {% set event_date = content.field_event_date.0['#text'] %}
+    {% set event_time_string = event_date|date('g:ia') %}
+    <div class="date">
+      {{ event_date|date('F jS, Y') }}
+    </div>
+
+    {% if node.field_destination_url.value %}
+    <div class="field-destination high-margin">
+      <p><strong class="tutorial note">Note:</strong> Event info is on the <a href="{{ node.field_destination_url.0.url }}">Cornell Calendar website</a>.</p>
+    </div>
+    {% endif %}
+    {{ node.body|view('full') }}
+  </div>
+
+</div>
+{% endblock %}

--- a/templates/events/node--event--full.html.twig
+++ b/templates/events/node--event--full.html.twig
@@ -10,7 +10,7 @@
     <div class="date">
       {{ event_date|date('F jS, Y') }}
     </div>
-    {%- if node.field_event_location.0 %},
+    {%- if node.field_event_location.0 %}
       <span class="event-location">{{ content.field_event_location }}</span>
     {% endif %}
 

--- a/templates/events/node--event--full.html.twig
+++ b/templates/events/node--event--full.html.twig
@@ -10,6 +10,9 @@
     <div class="date">
       {{ event_date|date('F jS, Y') }}
     </div>
+    {%- if node.field_event_location.0 %},
+      <span class="event-location">{{ content.field_event_location }}</span>
+    {% endif %}
 
     {% if node.field_destination_url.value %}
     <div class="field-destination high-margin">

--- a/templates/events/node--event.html.twig
+++ b/templates/events/node--event.html.twig
@@ -25,7 +25,7 @@
     </div>
 
     <div class="summary">
-      {{ content.field_short_description }}
+      {{ node.body|view('default') }}
     </div>
 
   </div>


### PR DESCRIPTION
with full body field, and article banner image style -- still based on drupal display settings for now, because, because...

also, use body field on "default" view mode

----

Additional details on companion PR: https://github.com/CU-CommunityApps/cd_drupal_upstream/pull/113