### PR TITLE
set root = true in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,9 @@
 # CSS Framework/CWD Theme: Drupal editor configuration normalization
 # @see http://editorconfig.org/
 
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
 # All files.
 [*]
 end_of_line = LF


### PR DESCRIPTION
This editorconfig file should only apply to this theme/this directory, it should not override editorconfig files in parent directories.

Note: I realize this theme is on its way out, but until we have a new Drupal Starter-kit, we still refer to this theme as a "model" as needed (and, it has come up on a current Drupal project).